### PR TITLE
빠진 문서 이동 페이지 및 단어 수정

### DIFF
--- a/Serving-patterns/Anti-patterns/README_ko.md
+++ b/Serving-patterns/Anti-patterns/README_ko.md
@@ -1,0 +1,5 @@
+# Serving Antipatterns
+
+- [Online bigsize pattern](./Online-bigsize-pattern/design_ja.md)
+
+- [All-in-one pattern](./All-in-one-pattern/design_ja.md)

--- a/Serving-patterns/Anti-patterns/README_ko.md
+++ b/Serving-patterns/Anti-patterns/README_ko.md
@@ -1,5 +1,5 @@
 # Serving Antipatterns
 
-- [Online bigsize pattern](./Online-bigsize-pattern/design_ja.md)
+- [Online bigsize pattern](./Online-bigsize-pattern/design_ko.md)
 
-- [All-in-one pattern](./All-in-one-pattern/design_ja.md)
+- [All-in-one pattern](./All-in-one-pattern/design_ko.md)

--- a/Serving-patterns/README_ko.md
+++ b/Serving-patterns/README_ko.md
@@ -36,7 +36,7 @@
 
 - Edge prediction pattern: To do
 
-- [Antipatterns](./Anti-patterns/README.md)
+- [Antipatterns](./Anti-patterns/README_ko.md)
 
   - [Online bigsize pattern](./Anti-patterns/Online-bigsize-pattern/design_ko.md)
 

--- a/Serving-patterns/README_ko.md
+++ b/Serving-patterns/README_ko.md
@@ -1,0 +1,43 @@
+# Serving patterns
+
+- [Web single pattern](./Web-single-pattern/design_ko.md)
+
+
+- [Synchronous pattern](./Synchronous-pattern/design_ko.md)
+
+
+- [Asynchronous pattern](./Asynchronous-pattern/design_ko.md)
+
+
+- [Batch pattern](./Batch-pattern/design_ko.md)
+
+
+- [Prep-pred pattern](./Prep-pred-pattern/design_ko.md)
+
+
+- [Microservice vertical pattern](./Microservice-vertical-pattern/design_ko.md)
+
+
+- [Microservice horizontal pattern](./Microservice-horizontal-pattern/design_ko.md)
+
+
+- [Prediction cache pattern](./Prediction-cache-pattern/design_ko.md)
+
+
+- [Data cache pattern](./Data-cache-pattern/design_ko.md)
+
+
+- [Prediction circuit break pattern](./Prediction-circuit-break-pattern/design_ko.md)
+
+
+- [Multiple stage prediction pattern](./Multiple-stage-prediction-pattern/design_ko.md)
+
+- [Serving template pattern](./Serving-template-pattern/design_ko.md)
+
+- Edge prediction pattern: To do
+
+- [Antipatterns](./Anti-patterns/README.md)
+
+  - [Online bigsize pattern](./Anti-patterns/Online-bigsize-pattern/design_ko.md)
+
+  - [All-in-one pattern](./Anti-patterns/All-in-one-pattern/design_ko.md)


### PR DESCRIPTION
Serving-patterns/README_ko.md 페이지와 Serving-patterns/Anti-patterns/README_ko.md 페이지가 누락된 것 같아서, 추가했습니다.